### PR TITLE
ROX-15044: Account for padded 0's when comparing numeric parts in SmartVerCmp()

### DIFF
--- a/cvefeed/nvd/smartvercmp.go
+++ b/cvefeed/nvd/smartvercmp.go
@@ -25,7 +25,8 @@ import (
 // but not for "2000" vs "11.7".
 // Returns -1 if v1 < v2, 1 if v1 > v2 and 0 if v1 == v2.
 func SmartVerCmp(v1, v2 string) int {
-	for s1, s2 := v1, v2; len(s1) > 0 && len(s2) > 0; {
+	s1, s2 := v1, v2
+	for len(s1) > 0 && len(s2) > 0 {
 		num1, cmpTo1, skip1 := parseVerParts(s1)
 		num2, cmpTo2, skip2 := parseVerParts(s2)
 
@@ -47,10 +48,10 @@ func SmartVerCmp(v1, v2 string) int {
 		s2 = s2[skip2:]
 	}
 	// everything is equal so far, the longest wins
-	if len(v1) > len(v2) {
+	if len(s1) > len(s2) {
 		return 1
 	}
-	if len(v2) > len(v1) {
+	if len(s2) > len(s1) {
 		return -1
 	}
 	return 0

--- a/cvefeed/nvd/smartvercmp_test.go
+++ b/cvefeed/nvd/smartvercmp_test.go
@@ -43,6 +43,8 @@ func TestSmartVerCmp(t *testing.T) {
 		{"1.4", "1.02", 1},
 		{"5.0", "08.0", -1},
 		{"10.0", "1.0", 1},
+		{"1.2.3", "1.2.03", 0},
+		{"1.2c.3", "1.02.03", 1},
 	}
 	for _, c := range cases {
 		t.Run(fmt.Sprintf("%q vs %q", c.v1, c.v2), func(t *testing.T) {


### PR DESCRIPTION
When numeric parts are compared, 0's are padded to the left to ensure they have the same length. When all components are the same, the code relies on the string length, but the padded zeros are ignored, resulting in incorrect results.

## Test

UTs.